### PR TITLE
Item relationship endpoints

### DIFF
--- a/app/controllers/api/v1/items/invoice_items_controller.rb
+++ b/app/controllers/api/v1/items/invoice_items_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::Items::InvoiceItemsController < ApplicationController
+
+  def index
+    item = Item.find(params[:item_id])
+    render json: InvoiceItemSerializer.new(item.invoice_items)
+  end
+end

--- a/app/controllers/api/v1/items/merchants_controller.rb
+++ b/app/controllers/api/v1/items/merchants_controller.rb
@@ -1,0 +1,7 @@
+class Api::V1::Items::MerchantsController < ApplicationController
+
+  def show
+    item = Item.find(params[:item_id])
+    render json: MerchantSerializer.new(item.merchant)
+  end
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -2,4 +2,5 @@ class Item < ApplicationRecord
   validates_presence_of :name, :description, :unit_price
 
   belongs_to :merchant
+  has_many :invoice_items
 end

--- a/app/serializers/invoice_item_serializer.rb
+++ b/app/serializers/invoice_item_serializer.rb
@@ -1,0 +1,5 @@
+class InvoiceItemSerializer
+  include FastJsonapi::ObjectSerializer
+
+  attributes :id, :quantity, :unit_price, :invoice_id, :item_id
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,8 @@ Rails.application.routes.draw do
       get '/items/find', to: 'items#show'
       get '/items/find_all', to: 'items#index'
       get '/items/random', to: 'items#random'
+      get '/items/:item_id/merchant', to: 'items/merchants#show'
+      get '/items/:item_id/invoice_items', to: 'items/invoice_items#index'
       resources :items, only: [:index, :show]
     end
   end

--- a/spec/requests/api/v1/items_request_spec.rb
+++ b/spec/requests/api/v1/items_request_spec.rb
@@ -66,4 +66,37 @@ describe 'Items API' do
       expect(response.body).to_not eq("")
     end
   end
+
+  describe 'relationship endpoints' do
+    before(:each) do
+      @merchant = create(:merchant)
+      @item_1 = create(:item, merchant_id: @merchant.id)
+    end
+
+    it "can return the associated merchant" do
+      get "/api/v1/items/#{@item_1.id}/merchant"
+
+      expect(response).to be_successful
+
+      merchant = JSON.parse(response.body)
+
+      expect(merchant["data"]["id"]).to eq(@merchant.id.to_s)
+    end
+
+    it "can return a collection of associated invoice items" do
+      customer = create(:customer)
+      invoice = create(:invoice, customer_id: customer.id)
+      create_list(:invoice_item, 3, item_id: @item_1.id, invoice_id: invoice.id)
+
+      get "/api/v1/items/#{@item_1.id}/invoice_items"
+
+      expect(response).to be_successful
+
+      invoice_items = JSON.parse(response.body)
+
+      expect(invoice_items["data"].count).to eq(3)
+
+
+    end
+  end
 end

--- a/spec/requests/api/v1/merchants_request_spec.rb
+++ b/spec/requests/api/v1/merchants_request_spec.rb
@@ -156,7 +156,7 @@ describe 'Merchants API' do
     expect(revenue["data"]["attributes"]["total_revenue"]).to eq("164350.0")
   end
 
-  xit "can return the customer with the most successful transactions with a merchant" do
+  it "can return the customer with the most successful transactions with a merchant" do
     customer_1 = Customer.create(first_name: 'Ryan', last_name: 'Hantak')
     customer_2 = Customer.create(first_name: 'Bob', last_name: 'G')
     merchant = Merchant.create(name: 'Excellent Electronics')


### PR DESCRIPTION
- Add endpoint for viewing an item's associated merchant `/items/merchant`
- Add endpoint for viewing an items's associated invoice_items `/items/invoice_items`
- Add serializer for invoice_items
- Items now `have_many` invoice items
